### PR TITLE
Vendor prefixes for flexbox.

### DIFF
--- a/assets/stylesheets/index.styl
+++ b/assets/stylesheets/index.styl
@@ -62,12 +62,20 @@ header
 
 
 .timezone-list
+  display: -webkit-box
+  display: -moz-box
+  display: -ms-flexbox
+  display: -webkit-flex
   display: flex
   height: 100%;
   padding-top: 3em
   justify-content: center
 
 .timezone
+  -webkit-box-flex: 1;
+  -moz-box-flex: 1;
+  -webkit-flex: 1;
+  -ms-flex: 1;
   flex: 1 30%
   max-width: 10em
   padding: 1em


### PR DESCRIPTION
Fixes #1, Safari was displaying it on one column since it needed the `-webkit-box-flex` and `display: -webkit-box`.

I took this as an opportunity to add the other prefixes for it (like `-ms-flexbox` or `-moz-flexbox`).
