### PR TITLE
Prevent person-info's pop-up content from overflowing the container

### DIFF
--- a/assets/stylesheets/index.styl
+++ b/assets/stylesheets/index.styl
@@ -57,12 +57,12 @@ h1, h2, h3, h4, h5
 
 .timezone
   padding: 1em
-  
+
 // .timezone-major
-  
+
 .timezone-people
   display: flex
-  
+
 .timezone-people-column
   min-width: $avatarSize
   margin-right: 1em
@@ -78,7 +78,7 @@ for hour in 0 1 2 3 4 5 6 7 22 23
   width: 80px
   text-align: left
   white-space: nowrap;
-  
+
   p
     margin: 0.3em 0
     overflow: hidden
@@ -86,7 +86,7 @@ for hour in 0 1 2 3 4 5 6 7 22 23
 
 .timezone-time
   margin: 0.3em 0
-  
+
 .timezone-name
   font-size: 0.6em
   text-transform: uppercase
@@ -114,7 +114,6 @@ for hour in 0 1 2 3 4 5 6 7 22 23
   z-index: 1000
   width: 140%
   max-width: 110px
-  max-height: 3em
   margin: 0 auto
   padding: 0.3em 0.4em 0.4em
 


### PR DESCRIPTION
Prevents this:
![person-info_popup_style_issue](https://cloud.githubusercontent.com/assets/1498567/6563388/121e159e-c6a1-11e4-8eb9-76d49ead5d9a.png)

Behaving like:

![person-info_popup_style_fix](https://cloud.githubusercontent.com/assets/1498567/6563385/0fe7fdee-c6a1-11e4-81f5-19d3dead45ca.png)

:)


